### PR TITLE
Исправил ссылку Home в хедере

### DIFF
--- a/src/sass/layouts/_header.scss
+++ b/src/sass/layouts/_header.scss
@@ -193,6 +193,12 @@
     font-weight: 700;
     color: #d41443;
     margin-left: 21px;
+
+    @include for-desktop {
+      margin: 0;
+      font-size: 16px;
+      line-height: 1.31;
+    }
   }
 
   &:hover {


### PR DESCRIPTION
Исправил ссылку Home в хедере. В десктопной версии страницы размер шрифта был 14px вместо 16px